### PR TITLE
Add Security Notes to Disable SSLv3

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ A collection of useful Nginx configuration snippets inspired by
 - [Security](#security)
     - [Enable Basic Authentication](#enable-basic-authentication)
     - [Only Allow Access From Localhost](#only-allow-access-from-localhost)
-    - [Disable SSLv3](#disable-sslLv3)
+    - [Strengthen SSL](#strengthen-ssl)
 - [Miscellaneous](#miscellaneous)
     - [Sub-Request Upon Completion](#sub-request-upon-completion)
     - [Enable Cross Origin Resource Sharing](#enable-cross-origin-resource-sharing)
@@ -245,10 +245,16 @@ location /local {
 }
 ```
 
-### Disable SSLv3
-Disable SSLv3 which is enabled by default. This prevents [POODLE SSL Attack](http://nginx.com/blog/nginx-poodle-ssl/).
+### Strengthen SSL
+Strengthen SSL Settings
+- Disable SSLv3 which is enabled by default. This prevents [POODLE SSL Attack](http://nginx.com/blog/nginx-poodle-ssl/).
+- Ciphers that best allow protection from Beast. [Mozilla Server Side TLS and Nginx]( https://wiki.mozilla.org/Security/Server_Side_TLS#Nginx)
 ```nginx
-ssl_protocols  TLSv1 TLSv1.1 TLSv1.2;  # don’t use SSLv3 ref: POODLE CVE-2014-356
+# don’t use SSLv3 ref: POODLE CVE-2014-356 - http://nginx.com/blog/nginx-poodle-ssl/
+ssl_protocols  TLSv1 TLSv1.1 TLSv1.2;  
+
+# Ciphers set to best allow protection from Beast, while providing forwarding secrecy, as defined by Mozilla (Intermediate Set) - https://wiki.mozilla.org/Security/Server_Side_TLS#Nginx
+ssl_ciphers ECDHE-RSA-AES128-GCM-SHA256:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES256-GCM-SHA384:DHE-RSA-AES128-GCM-SHA256:DHE-DSS-AES128-GCM-SHA256:kEDH+AESGCM:ECDHE-RSA-AES128-SHA256:ECDHE-ECDSA-AES128-SHA256:ECDHE-RSA-AES128-SHA:ECDHE-ECDSA-AES128-SHA:ECDHE-RSA-AES256-SHA384:ECDHE-ECDSA-AES256-SHA384:ECDHE-RSA-AES256-SHA:ECDHE-ECDSA-AES256-SHA:DHE-RSA-AES128-SHA256:DHE-RSA-AES128-SHA:DHE-DSS-AES128-SHA256:DHE-RSA-AES256-SHA256:DHE-DSS-AES256-SHA:DHE-RSA-AES256-SHA:AES128-GCM-SHA256:AES256-GCM-SHA384:AES128-SHA256:AES256-SHA256:AES128-SHA:AES256-SHA:AES:CAMELLIA:DES-CBC3-SHA:!aNULL:!eNULL:!EXPORT:!DES:!RC4:!MD5:!PSK:!aECDH:!EDH-DSS-DES-CBC3-SHA:!EDH-RSA-DES-CBC3-SHA:!KRB5-DES-CBC3-SHA;
 ```
 
 ## Miscellaneous

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ A collection of useful Nginx configuration snippets inspired by
 - [Security](#security)
     - [Enable Basic Authentication](#enable-basic-authentication)
     - [Only Allow Access From Localhost](#only-allow-access-from-localhost)
+    - [Disable SSLv3](#disable-sslLv3)
 - [Miscellaneous](#miscellaneous)
     - [Sub-Request Upon Completion](#sub-request-upon-completion)
     - [Enable Cross Origin Resource Sharing](#enable-cross-origin-resource-sharing)
@@ -244,6 +245,11 @@ location /local {
 }
 ```
 
+### Disable SSLv3
+Disable SSLv3 which is enabled by default. This prevents [POODLE SSL Attack](http://nginx.com/blog/nginx-poodle-ssl/).
+```nginx
+ssl_protocols  TLSv1 TLSv1.1 TLSv1.2;  # don’t use SSLv3 ref: POODLE CVE-2014-356
+```
 
 ## Miscellaneous
 


### PR DESCRIPTION
Add notes to disable SSLv3 to prevent POODLE SSL attack CVE-2014-356.

Reference:
- http://nginx.com/blog/nginx-poodle-ssl/
- https://wiki.mozilla.org/Security/Server_Side_TLS#Nginx
- https://github.com/h5bp/server-configs-nginx/blob/master/h5bp/directive-only/ssl.conf
